### PR TITLE
Updates to Windows batch file

### DIFF
--- a/cantera-dev/bld.bat
+++ b/cantera-dev/bld.bat
@@ -25,9 +25,8 @@ SET PY_MAJ_VER=%PY_VER:~0,1%
 :: Set the number of CPUs to use in building
 SET /A CPU_USE=%CPU_COUNT% / 2
 
-:: Using the activate script didn't seems to work, so set the PATH manually
-SET OLD_PATH=%PATH%
-SET PATH=%PREFIX:~0,-6%cantera-builder\bin;%PREFIX:~0,-6%cantera-builder\Scripts;%PATH%
+:: Set up to use the cantera-builder environment
+CALL activate.bat cantera-builder
 
 :: Have to use CALL to prevent the script from exiting after calling SCons
 CALL scons clean
@@ -56,9 +55,9 @@ CALL scons build -j%CPU_COUNT% python3_package=y python3_cmd="%PYTHON%" python_p
 GOTO BUILD_SUCCESS
 
 :BUILD_SUCCESS
-:: Remove the builder environment and reset the path
+:: Reset the environment and remove the builder environment
+CALL deactivate.bat
 CALL conda env remove -yq -n cantera-builder
-SET PATH=%OLD_PATH%
 
 :: Change to the Python interface directory and run the installer using the
 :: proper version of Python.

--- a/cantera-dev/bld.bat
+++ b/cantera-dev/bld.bat
@@ -7,7 +7,7 @@ IF %ARCH% EQU 64 (
 )
 
 :: Remove the old builder environment, if it exists
-CALL conda env remove -y -n cantera-builder
+CALL conda env remove -yq -n cantera-builder
 
 :: Create a conda environment to build Cantera. It has to be Python 2, for
 :: Scons compatibility. When SCons is available for Python 3, these machinations
@@ -16,7 +16,7 @@ CALL conda env remove -y -n cantera-builder
 :: the conda repositories is 2.3.0. Unfortunately, using VS 2015 requires SCons
 :: 2.4.1. This version is available from my channel on anaconda.org, so we add
 :: -c bryanwweber to pick up SCons from that channel.
-CALL conda create -y -n cantera-builder -c cantera/label/builddeps python=2 cython numpy pywin32 scons 3to2
+CALL conda create -yq -n cantera-builder -c cantera/label/builddeps python=2 cython numpy pywin32 scons 3to2
 
 :: The major version of the Python that will be used for the installer, not the
 :: version used for building
@@ -57,7 +57,7 @@ GOTO BUILD_SUCCESS
 
 :BUILD_SUCCESS
 :: Remove the builder environment and reset the path
-CALL conda env remove -y -n cantera-builder
+CALL conda env remove -yq -n cantera-builder
 SET PATH=%OLD_PATH%
 
 :: Change to the Python interface directory and run the installer using the


### PR DESCRIPTION
Small changes to improve Windows builds. Using the activate/deactivate scripts seems better to me because they do several other tasks besides setting the path. Most likely the reason it didn't work before is that I didn't `CALL` the scripts.