### PR TITLE
[WIP] Patch version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,4 +36,6 @@ install:
 
 script:
   - conda build cantera --python=2.7 --python=3.4 --python=3.5 --numpy=1.11
-  - anaconda -t $ANACONDA_TOKEN upload --force -l dev $HOME/miniconda/conda-bld/*/cantera*.tar.bz2
+  - if [[ "$TRAVIS_BRANCH" == "master" ]]; then
+      anaconda -t $ANACONDA_TOKEN upload --force -l dev $HOME/miniconda/conda-bld/*/cantera*.tar.bz2
+    fi

--- a/cantera/bld.bat
+++ b/cantera/bld.bat
@@ -40,6 +40,7 @@ ECHO matlab_toolbox='n' >> cantera.conf
 ECHO debug='n' >> cantera.conf
 ECHO f90_interface='n' >> cantera.conf
 ECHO system_sundials='n' >> cantera.conf
+ECHO cantera_version='%PKG_VERSION%' >> cantera.conf
 
 :: Select which version of the interface should be built
 IF %PY_MAJ_VER% EQU 2 GOTO PYTHON2

--- a/cantera/build.sh
+++ b/cantera/build.sh
@@ -24,6 +24,7 @@ echo "system_sundials='n'" >> cantera.conf
 echo "blas_lapack_libs = 'mkl_rt,dl'" >> cantera.conf
 echo "debug='n'" >> cantera.conf
 echo "blas_lapack_dir = '$PREFIX/lib'" >> cantera.conf
+echo "cantera_version = '$PKG_VERSION'" >> cantera.conf
 
 if [[ "$CONDA_ARCH" == "linux_x86" ]]; then
   echo "cc_flags='-m32'" >> cantera.conf

--- a/cantera/meta.yaml
+++ b/cantera/meta.yaml
@@ -27,6 +27,8 @@ requirements:
 test:
     imports:
       - cantera
+    commands:
+      - python -m unittest -v cantera.test.test_transport cantera.test.test_purefluid cantera.test.test_mixture
 about:
     home: http://www.cantera.org
     summary: "Chemical kinetics, thermodynamics, and transport tool suite"

--- a/cantera/meta.yaml
+++ b/cantera/meta.yaml
@@ -1,9 +1,13 @@
+{% set version = "2.3.0a3" %}
+
 package:
     name: cantera
-    version: "2.3.0a3"
+    version: {{ version }}
 source:
     git_url: https://github.com/Cantera/cantera.git
     git_tag: master
+    patches:
+      - version.patch
 build:
     number: 1
     string: np{{CONDA_NPY}}py{{CONDA_PY}}_{{PKG_BUILDNUM}}_g{{GIT_FULL_HASH[:7]}}

--- a/cantera/meta.yaml
+++ b/cantera/meta.yaml
@@ -9,7 +9,7 @@ source:
     patches:
       - version.patch
 build:
-    number: 1
+    number: 2
     string: np{{CONDA_NPY}}py{{CONDA_PY}}_{{PKG_BUILDNUM}}_g{{GIT_FULL_HASH[:7]}}
     script_env:
       - CONDA_ARCH

--- a/cantera/version.patch
+++ b/cantera/version.patch
@@ -1,0 +1,21 @@
+diff --git a/SConstruct b/SConstruct
+index 68a50dd..f9c7af1 100644
+--- a/SConstruct
++++ b/SConstruct
+@@ -556,6 +556,8 @@ config_options = [
+            with a prefix like '/opt/cantera'. 'debian' installs to the stage
+            directory in a layout used for generating Debian packages.""",
+      defaults.fsLayout, ('standard','compact','debian')),
++    ('cantera_version',
++     'Version of Cantera being built.', '')
+ ]
+ 
+ opts.AddVariables(*config_options)
+@@ -603,7 +605,6 @@ for arg in ARGUMENTS:
+         sys.exit(1)
+ 
+ # Require a StrictVersion-compatible version
+-env['cantera_version'] = "2.3.0a3"
+ ctversion = StrictVersion(env['cantera_version'])
+ # For use where pre-release tags are not permitted (MSI, sonames)
+ env['cantera_pure_version'] = '.'.join(str(x) for x in ctversion.version)


### PR DESCRIPTION
Set the version in the meta.yaml file using the Jinja template syntax. To apply this version to the build, we have to patch SConstruct to allow setting the build version from cantera.conf. This is unfortunately somewhat fragile because any changes in SConstruct may invalidate the patch and cause a failure. It also means that the version has to be changed in two places in the repository for a version bump, once in meta.yaml, the other in the deleted line in the patch.

Also add some Python module testing.

The CI is failing because there's an error in conda build when multiple Python versions are specified. I can run a single build locally no problem.