### PR TITLE
Add check if cantera-builder env exists before removing

### DIFF
--- a/cantera/build.sh
+++ b/cantera/build.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
 # Remove the old builder environement, if it exists
-conda env remove -yq -n cantera-builder
+if [[ $(conda env list) == *cantera-builder* ]]; then
+    conda env remove -yq -n cantera-builder
+fi
 
 # Create a conda environment to build Cantera. It has to be Python 2, for
 # SCons compatibility. When SCons is available for Python 3, these machinations


### PR DESCRIPTION
Not sure exactly what version this changed, but for conda 4.2.7, trying to remove an environment that doesn't exist (i.e., what we do with the `cantera-builder` environment) raises an exception. We need to make an if/else statement to check if the environment exists. 