### PR TITLE
Version work

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,9 @@ install:
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - conda config --set always_yes yes --set changeps1 no
-  - conda update -q conda
+  - conda install -q anaconda-client conda-build=2.0.6 conda=4.2.9
   - conda info -a
-  - conda install -y anaconda-client conda-build
+  - conda list
 
 script:
   - conda build cantera --python=2.7 --numpy=1.11

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,11 @@ matrix:
   - env: CONDA_ARCH=osx_x64
     os: osx
 install:
+  # Using Miniconda 2 saves having to download Python 2 for the cantera-builder environment
   - if [[ "$CONDA_ARCH" == "linux_x64" ]]; then
       wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
     elif [[ "$CONDA_ARCH" == "linux_x86" ]]; then
-      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86.sh -O miniconda.sh;
+      wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86.sh -O miniconda.sh;
     elif [[ "$CONDA_ARCH" == "osx_x64" ]]; then
       curl https://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-x86_64.sh -o miniconda.sh;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,6 @@ script:
   - conda build cantera --python=2.7 --numpy=1.11
   - conda build cantera --python=3.4 --numpy=1.11
   - conda build cantera --python=3.5 --numpy=1.11
-  - if [[ "${TRAVIS_PULL_REQUEST}" == "false" && "${TRAVIS_BRANCH}" == "master" ]]; then
-      anaconda -t $ANACONDA_TOKEN upload --force -l dev $HOME/miniconda/conda-bld/*/cantera*.tar.bz2
+  - if [ "${TRAVIS_PULL_REQUEST}" == "false" ] && [ "${TRAVIS_BRANCH}" == "master" ]; then
+      anaconda -t $ANACONDA_TOKEN upload --force -l dev $HOME/miniconda/conda-bld/*/cantera*.tar.bz2;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,31 +4,49 @@ env:
   global:
     secure: "lipzTB4mywydfk2wz+4AygG8tO5W6n+PvtFTSE9GBTSEmBjja2dIqc7DUjJuIqrve2X1Hon6AfiwsaHTYhO/ev+mACnZ/aKkkemSPRh/SlWUnGKzc/zXc8rNOmOdhKVTHUkJyXJZF0ZZvPC+xj3JGZdOKWXFLgiszwqQO/HLddWtl7+HoJnLLDKLHf80dEpmOMF9uaWezN3HzZtGLeJX5x1G8sqx6umUlcu7EiYbeBoF3HJVLiAkMCit5eJwk7nP6SpWd9xyYWPmn4Fu+4jMa29ItlXgL3G0i9yDwkpD7jaXTxJNOMQ7OxM9wBPI5Ef5ZasG6xBJeqap6vFSszu6VuignxVA4nDkvLDJohuSeRWlhZOAn2FZbI6DQIkOY3MfZcac1ImPhuoq86VnWeuLVZeb9qXKTUDQjamumywnYSRA9ZUbY6uq1CaChknXIOSb2kxJuF+WWsyZjyGp27OvGAev8Nm+IO/It/ZfID3WWB4cJFGoS1vyPFIfWKZhjhNYIrxXBD786McWkGlNcz8u9ukSTaa+cSCFIZgO9QCXJEsPtUHeJZx84MuUtqsIOQTRIVNIvQkzEctBNm8AaJ3eRugbYQFHEdk1lsvHpzgdU3aIj6OgV1dWaUUZzdbWxzL1lyGR8v/pZ+UrBaWuVFU8Y9h9jLF4uPhP7hp+xkR2V3A="
 
-  matrix:
-    - BUILD_PYTHON="2.7"
-    - BUILD_PYTHON="3.4"
-    - BUILD_PYTHON="3.5"
-    - OS_ARCH="x64"
+addons: &32-bit-deps
+  apt:
+    packages:
+      - libc6:i386
+      - libc6-dev:i386
+      - zlib1g:i386
+      - gcc-multilib
+      - g++-multilib
 
 matrix:
   include:
     - os: linux
-      env: OS_ARCH="x86"
-      addons:
-        apt:
-          packages:
-            - libc6:i386
-            - libc6-dev:i386
-            - zlib1g:i386
-            - gcc-multilib
-            - g++-multilib
+      env: BUILD_PYTHON="2.7" BUILD_ARCH="x86"
+      addons: *32-bit-deps
 
-os:
-  - linux
-  - osx
+    - os: linux
+      env: BUILD_PYTHON="3.4" BUILD_ARCH="x86"
+      addons: *32-bit-deps
+
+    - os: linux
+      env: BUILD_PYTHON="3.5" BUILD_ARCH="x86"
+      addons: *32-bit-deps
+
+    - os: linux
+      env: BUILD_PYTHON="2.7" BUILD_ARCH="x64"
+
+    - os: linux
+      env: BUILD_PYTHON="3.4" BUILD_ARCH="x64"
+
+    - os: linux
+      env: BUILD_PYTHON="3.5" BUILD_ARCH="x64"
+
+    - os: osx
+      env: BUILD_PYTHON="2.7" BUILD_ARCH="x64"
+
+    - os: osx
+      env: BUILD_PYTHON="3.4" BUILD_ARCH="x64"
+
+    - os: osx
+      env: BUILD_PYTHON="3.5" BUILD_ARCH="x64"
 
 install:
-  - export CONDA_ARCH="${TRAVIS_OS_NAME}_${OS_ARCH}"
+  - export CONDA_ARCH="${TRAVIS_OS_NAME}_${BUILD_ARCH}"
   # Using Miniconda 2 saves having to download Python 2 for the cantera-builder environment
   - if [[ "$CONDA_ARCH" == "linux_x64" ]]; then
       wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,4 +39,6 @@ script:
   - conda build cantera --python=2.7 --numpy=1.11
   - conda build cantera --python=3.4 --numpy=1.11
   - conda build cantera --python=3.5 --numpy=1.11
-  - anaconda -t $ANACONDA_TOKEN upload --force -l dev $HOME/miniconda/conda-bld/*/cantera*.tar.bz2
+  - if [[ "${TRAVIS_PULL_REQUEST}" == "false" && "${TRAVIS_BRANCH}" == "master" ]]; then
+      anaconda -t $ANACONDA_TOKEN upload --force -l dev $HOME/miniconda/conda-bld/*/cantera*.tar.bz2
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,23 +3,32 @@ sudo: false
 env:
   global:
     secure: "lipzTB4mywydfk2wz+4AygG8tO5W6n+PvtFTSE9GBTSEmBjja2dIqc7DUjJuIqrve2X1Hon6AfiwsaHTYhO/ev+mACnZ/aKkkemSPRh/SlWUnGKzc/zXc8rNOmOdhKVTHUkJyXJZF0ZZvPC+xj3JGZdOKWXFLgiszwqQO/HLddWtl7+HoJnLLDKLHf80dEpmOMF9uaWezN3HzZtGLeJX5x1G8sqx6umUlcu7EiYbeBoF3HJVLiAkMCit5eJwk7nP6SpWd9xyYWPmn4Fu+4jMa29ItlXgL3G0i9yDwkpD7jaXTxJNOMQ7OxM9wBPI5Ef5ZasG6xBJeqap6vFSszu6VuignxVA4nDkvLDJohuSeRWlhZOAn2FZbI6DQIkOY3MfZcac1ImPhuoq86VnWeuLVZeb9qXKTUDQjamumywnYSRA9ZUbY6uq1CaChknXIOSb2kxJuF+WWsyZjyGp27OvGAev8Nm+IO/It/ZfID3WWB4cJFGoS1vyPFIfWKZhjhNYIrxXBD786McWkGlNcz8u9ukSTaa+cSCFIZgO9QCXJEsPtUHeJZx84MuUtqsIOQTRIVNIvQkzEctBNm8AaJ3eRugbYQFHEdk1lsvHpzgdU3aIj6OgV1dWaUUZzdbWxzL1lyGR8v/pZ+UrBaWuVFU8Y9h9jLF4uPhP7hp+xkR2V3A="
+
+  matrix:
+    - BUILD_PYTHON="2.7"
+    - BUILD_PYTHON="3.4"
+    - BUILD_PYTHON="3.5"
+    - OS_ARCH="x64"
+
 matrix:
   include:
-  - env: CONDA_ARCH=linux_x64
-    os: linux
-  - env: CONDA_ARCH=linux_x86
-    os: linux
-    addons:
-      apt:
-        packages:
-          - libc6:i386
-          - libc6-dev:i386
-          - zlib1g:i386
-          - gcc-multilib
-          - g++-multilib
-  - env: CONDA_ARCH=osx_x64
-    os: osx
+    - os: linux
+      env: OS_ARCH="x86"
+      addons:
+        apt:
+          packages:
+            - libc6:i386
+            - libc6-dev:i386
+            - zlib1g:i386
+            - gcc-multilib
+            - g++-multilib
+
+os:
+  - linux
+  - osx
+
 install:
+  - export CONDA_ARCH="${TRAVIS_OS_NAME}_${OS_ARCH}"
   # Using Miniconda 2 saves having to download Python 2 for the cantera-builder environment
   - if [[ "$CONDA_ARCH" == "linux_x64" ]]; then
       wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
@@ -36,9 +45,9 @@ install:
   - conda list
 
 script:
-  - conda build cantera --python=2.7 --numpy=1.11
-  - conda build cantera --python=3.4 --numpy=1.11
-  - conda build cantera --python=3.5 --numpy=1.11
+  - conda build cantera --python=${BUILD_PYTHON} --numpy=1.11
   - if [ "${TRAVIS_PULL_REQUEST}" == "false" ] && [ "${TRAVIS_BRANCH}" == "master" ]; then
       anaconda -t $ANACONDA_TOKEN upload --force -l dev $HOME/miniconda/conda-bld/*/cantera*.tar.bz2;
+    else
+      echo "Nothing was uploaded because this isn't the master branch or it's a pull request.";
     fi

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+This repository hosts the recipe to build the Python interface for Cantera into a conda package. The package is built on Appveyor and TravisCI and uploaded to Anaconda.org automatically.
+
+[![Build status](https://ci.appveyor.com/api/projects/status/auhd35qn9cdmkpoj/branch/master?svg=true)](https://ci.appveyor.com/project/Cantera/cantera/branch/master) [![Build Status](https://travis-ci.org/Cantera/conda-recipes.svg?branch=master)](https://travis-ci.org/Cantera/conda-recipes)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,28 +3,42 @@ environment:
   ANACONDA_KEY:
     secure: kiAnoYuLn2aWvx3eXzTZ+qv4sgRiAQIGv54SxfBeket2lYj9VBDyGjYxZ/K2X5Wf
 
+  matrix:
+    - PYTHON_LOC: "C:\\Miniconda"
+      PYTHON_VERSION: "2.7"
+      BUILD_ARCH: "32"
+
+    - PYTHON_LOC: "C:\\Miniconda"
+      PYTHON_VERSION: "3.4"
+      BUILD_ARCH: "32"
+
+    - PYTHON_LOC: "C:\\Miniconda"
+      PYTHON_VERSION: "3.5"
+      BUILD_ARCH: "32"
+
+    - PYTHON_LOC: "C:\\Miniconda-x64"
+      PYTHON_VERSION: "2.7"
+      BUILD_ARCH: "64"
+
+    - PYTHON_LOC: "C:\\Miniconda-x64"
+      PYTHON_VERSION: "3.4"
+      BUILD_ARCH: "64"
+
+    - PYTHON_LOC: "C:\\Miniconda-x64"
+      PYTHON_VERSION: "3.5"
+      BUILD_ARCH: "64"
+
 install:
   - cmd: |
-      set ORIGPATH=%PATH%
-      set PATH=C:\Miniconda;C:\Miniconda\Scripts;%ORIGPATH%
-      call conda install -y anaconda-client conda-build
-      set PATH=C:\Miniconda-x64;C:\Miniconda-x64\Scripts;%ORIGPATH%
-      call conda install -y anaconda-client conda-build
+      set PATH=%PYTHON_LOC%;%PYTHON_LOC%\Scripts;%PATH%
+      call conda install -yq anaconda-client conda=4.2.9 conda-build=2.0.6
 
 build_script:
   - cmd: |
-      set PATH=C:\Miniconda;C:\Miniconda\Scripts;%ORIGPATH%
-      call conda build cantera --python=2.7 --numpy=1.11
-      call conda build cantera --python=3.4 --numpy=1.11
-      call conda build cantera --python=3.5 --numpy=1.11
-      set PATH=C:\Miniconda-x64;C:\Miniconda-x64\Scripts;%ORIGPATH%
-      call conda build cantera --python=2.7 --numpy=1.11
-      call conda build cantera --python=3.4 --numpy=1.11
-      call conda build cantera --python=3.5 --numpy=1.11
+      set PATH=%PYTHON_LOC%;%PYTHON_LOC%\Scripts;%PATH%
+      call conda build cantera --python=%PYTHON_VERSION% --numpy=1.11
 
 deploy_script:
   - cmd: |
-      set PATH=C:\Miniconda;C:\Miniconda\Scripts;%ORIGPATH%
-      call anaconda -t %ANACONDA_KEY% upload --force -l dev C:\Miniconda\conda-bld\win-32\cantera*.tar.bz2
-      set PATH=C:\Miniconda-x64;C:\Miniconda-x64\Scripts;%ORIGPATH%
-      call anaconda -t %ANACONDA_KEY% upload --force -l dev C:\Miniconda-x64\conda-bld\win-64\cantera*.tar.bz2
+      set PATH=%PYTHON_LOC%;%PYTHON_LOC%\Scripts;%PATH%
+      call anaconda -t %ANACONDA_KEY% upload --force -l dev %PYTHON_LOC%\conda-bld\win-%BUILD_ARCH%\cantera*.tar.bz2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,8 +31,8 @@ environment:
 install:
   - cmd: |
       set PATH=%PYTHON_LOC%;%PYTHON_LOC%\Scripts;%PATH%
-      call conda info -a
       call conda install -yq anaconda-client conda=4.2.9 conda-build=2.0.6
+      call conda info -a
       call conda list
 
 build_script:
@@ -42,5 +42,9 @@ build_script:
 
 deploy_script:
   - cmd: |
-      set PATH=%PYTHON_LOC%;%PYTHON_LOC%\Scripts;%PATH%
-      call anaconda -t %ANACONDA_KEY% upload --force -l dev %PYTHON_LOC%\conda-bld\win-%BUILD_ARCH%\cantera*.tar.bz2
+      if "%APPVEYOR_REPO_BRANCH%" == "master" (
+        if "%APPVEYOR_PULL_REQUEST_NUMBER%" == "" (
+          set PATH=%PYTHON_LOC%;%PYTHON_LOC%\Scripts;%PATH%
+          call anaconda -t %ANACONDA_KEY% upload --force -l dev %PYTHON_LOC%\conda-bld\win-%BUILD_ARCH%\cantera*.tar.bz2
+        )
+      )

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,7 +31,9 @@ environment:
 install:
   - cmd: |
       set PATH=%PYTHON_LOC%;%PYTHON_LOC%\Scripts;%PATH%
+      call conda info -a
       call conda install -yq anaconda-client conda=4.2.9 conda-build=2.0.6
+      call conda list
 
 build_script:
   - cmd: |

--- a/cantera/bld.bat
+++ b/cantera/bld.bat
@@ -37,7 +37,6 @@ CALL scons clean
 :: Put important settings into cantera.conf for the build. Use VS 2015 to
 :: compile the interface.
 ECHO msvc_version='14.0' >> cantera.conf
-ECHO env_vars='all' >> cantera.conf
 ECHO matlab_toolbox='n' >> cantera.conf
 ECHO debug='n' >> cantera.conf
 ECHO f90_interface='n' >> cantera.conf

--- a/cantera/bld.bat
+++ b/cantera/bld.bat
@@ -7,12 +7,12 @@ IF %ARCH% EQU 64 (
 )
 
 :: Remove the old builder environment, if it exists
-CALL conda env remove -yq -p %PREFIX:~0,-6%cantera-builder
+CALL conda env remove -yq -p "%PREFIX%\..\cantera-builder"
 
 :: Create a conda environment to build Cantera. It has to be Python 2, for
 :: Scons compatibility. When SCons is available for Python 3, these machinations
 :: can be removed
-CALL conda create -yq -p %PREFIX:~0,-6%cantera-builder -c cantera/label/builddeps python=2 cython numpy=%NPY_VER% pywin32 scons 3to2
+CALL conda create -yq -p "%PREFIX%\..\cantera-builder" -c cantera/label/builddeps python=2 cython numpy="%NPY_VER%" pywin32 scons 3to2
 
 :: The major version of the Python that will be used for the installer, not the
 :: version used for building
@@ -20,12 +20,10 @@ SET PY_MAJ_VER=%PY_VER:~0,1%
 
 :: Set the number of CPUs to use in building
 SET /A CPU_USE=%CPU_COUNT% / 2
-IF "%CPU_USE%" EQU "0" SET CPU_USE=1
+IF %CPU_USE% EQU 0 SET CPU_USE=1
 
-:: Using the activate script doesn't work in PowerShell, and in cmd.exe it gives an
-:: "Input line too long" error, so set the PATH manually.
-SET OLD_PATH=%PATH%
-SET PATH=%PREFIX:~0,-6%cantera-builder\bin;%PREFIX:~0,-6%cantera-builder\Scripts;%PATH%
+SET OLD_CONDA_ENV="%CONDA_DEFAULT_ENV%"
+CALL "%ROOT%\Scripts\activate.bat" "%PREFIX%\..\cantera-builder"
 
 :: Have to use CALL to prevent the script from exiting after calling SCons
 CALL scons clean
@@ -54,8 +52,9 @@ GOTO BUILD_SUCCESS
 
 :BUILD_SUCCESS
 :: Remove the builder environment and reset the path
-CALL conda env remove -yq -p %PREFIX:~0,-6%cantera-builder
-SET PATH=%OLD_PATH%
+CALL "%ROOT%\Scripts\activate.bat" "%OLD_CONDA_ENV%"
+CALL conda env remove -yq -p "%PREFIX%"\..\cantera-builder
+:: SET PATH=%OLD_PATH%
 
 :: Change to the Python interface directory and run the installer using the
 :: proper version of Python.

--- a/cantera/bld.bat
+++ b/cantera/bld.bat
@@ -24,6 +24,7 @@ SET PY_MAJ_VER=%PY_VER:~0,1%
 
 :: Set the number of CPUs to use in building
 SET /A CPU_USE=%CPU_COUNT% / 2
+IF "%CPU_USE%" EQU "0" SET CPU_USE=1
 
 :: Using the activate script doesn't work in PowerShell, and in cmd.exe it gives an
 :: "Input line too long" error, so set the PATH manually.
@@ -43,17 +44,17 @@ ECHO f90_interface='n' >> cantera.conf
 ECHO system_sundials='n' >> cantera.conf
 
 :: Select which version of the interface should be built
-IF %PY_MAJ_VER% EQU 2 GOTO PYTHON2
-IF %PY_MAJ_VER% EQU 3 GOTO PYTHON3
+IF "%PY_MAJ_VER%" EQU "2" GOTO PYTHON2
+IF "%PY_MAJ_VER%" EQU "3" GOTO PYTHON3
 
 :PYTHON2
 ECHO Building for Python 2
-CALL scons build -j%CPU_COUNT% python3_package=n python_cmd="%PYTHON%" python_package=full
+CALL scons build -j%CPU_USE% python3_package=n python_cmd="%PYTHON%" python_package=full
 GOTO BUILD_SUCCESS
 
 :PYTHON3
 ECHO Building for Python 3
-CALL scons build -j%CPU_COUNT% python3_package=y python3_cmd="%PYTHON%" python_package=none
+CALL scons build -j%CPU_USE% python3_package=y python3_cmd="%PYTHON%" python_package=none
 GOTO BUILD_SUCCESS
 
 :BUILD_SUCCESS

--- a/cantera/bld.bat
+++ b/cantera/bld.bat
@@ -12,7 +12,7 @@ CALL conda env remove -yq -p %PREFIX:~0,-6%cantera-builder
 :: Create a conda environment to build Cantera. It has to be Python 2, for
 :: Scons compatibility. When SCons is available for Python 3, these machinations
 :: can be removed
-CALL conda create -yq -p %PREFIX:~0,-6%cantera-builder -c cantera/label/builddeps python=2 cython numpy pywin32 scons 3to2
+CALL conda create -yq -p %PREFIX:~0,-6%cantera-builder -c cantera/label/builddeps python=2 cython numpy=%NPY_VER% pywin32 scons 3to2
 
 :: The major version of the Python that will be used for the installer, not the
 :: version used for building

--- a/cantera/bld.bat
+++ b/cantera/bld.bat
@@ -12,10 +12,6 @@ CALL conda env remove -yq -p %PREFIX:~0,-6%cantera-builder
 :: Create a conda environment to build Cantera. It has to be Python 2, for
 :: Scons compatibility. When SCons is available for Python 3, these machinations
 :: can be removed
-:: Important: As of 24-Dec-2015, the most recent version of SCons available in
-:: the conda repositories is 2.3.0. Unfortunately, using VS 2015 requires SCons
-:: 2.4.1. This version is available from the cantera channel on anaconda.org, so we add
-:: -c cantera/label/builddeps to pick up SCons from that channel.
 CALL conda create -yq -p %PREFIX:~0,-6%cantera-builder -c cantera/label/builddeps python=2 cython numpy pywin32 scons 3to2
 
 :: The major version of the Python that will be used for the installer, not the

--- a/cantera/build.sh
+++ b/cantera/build.sh
@@ -1,21 +1,22 @@
 #!/bin/bash
 
 # Remove the old builder environement, if it exists
-if [[ $(conda env list) == *cantera-builder* ]]; then
-    conda env remove -yq -n cantera-builder
+if [[ -d "$PREFIX/../cantera-builder" ]]; then
+    conda env remove -yq -p "$PREFIX/../cantera-builder"
 fi
 
 # Create a conda environment to build Cantera. It has to be Python 2, for
 # SCons compatibility. When SCons is available for Python 3, these machinations
 # can be removed
-conda create -yq -n cantera-builder -c cantera/label/builddeps python=2 numpy=$NPY_VER scons cython mkl 3to2
+conda create -yq -p "$PREFIX/../cantera-builder" -c cantera/label/builddeps python=2 numpy=$NPY_VER scons cython mkl 3to2
 
 # The major version of the Python that will be used for the installer, not the
 # version used for building
 PY_MAJ_VER=${PY_VER:0:1}
 
+OLD_CONDA_ENV="$CONDA_DEFAULT_ENV"
 set +x
-source activate cantera-builder
+source activate "$PREFIX/../cantera-builder"
 
 scons clean
 
@@ -43,9 +44,9 @@ fi
 
 # Remove the builder environment
 set +x
-source deactivate
+source activate "$OLD_CONDA_ENV"
 set -x
-conda env remove -yq -n cantera-builder
+conda env remove -yq -p "$PREFIX/../cantera-builder"
 
 # Change to the Python interface directory and run the installer using the
 # proper version of Python.

--- a/cantera/build.sh
+++ b/cantera/build.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
 # Remove the old builder environement, if it exists
-conda env remove -yq -n cantera-builder
+if [[ $(conda env list) == *cantera-builder* ]]; then
+    conda env remove -yq -n cantera-builder
+fi
 
 # Create a conda environment to build Cantera. It has to be Python 2, for
 # SCons compatibility. When SCons is available for Python 3, these machinations

--- a/cantera/meta.yaml
+++ b/cantera/meta.yaml
@@ -23,6 +23,8 @@ requirements:
 test:
     imports:
       - cantera
+    commands:
+      - python -m unittest -v cantera.test.test_transport cantera.test.test_purefluid cantera.test.test_mixture
 about:
     home: http://www.cantera.org
     summary: "Chemical kinetics, thermodynamics, and transport tool suite"

--- a/cantera/meta.yaml
+++ b/cantera/meta.yaml
@@ -1,11 +1,13 @@
+{% set data = load_file_regex(load_file='SConstruct', regex_pattern="env\\['cantera_version'\\] = .([\d.abrc]+).") %}
+
 package:
     name: cantera
-    version: "2.3.0a3"
+    version: {{ data.group(1) }}
 source:
     git_url: https://github.com/Cantera/cantera.git
     git_tag: master
 build:
-    number: 1
+    number: 2
     string: np{{CONDA_NPY}}py{{CONDA_PY}}_{{PKG_BUILDNUM}}_g{{GIT_FULL_HASH[:7]}}
     script_env:
       - CONDA_ARCH

--- a/cantera/meta.yaml
+++ b/cantera/meta.yaml
@@ -14,11 +14,11 @@ requirements:
       - python >=2.7,<3|>=3.3,{{PY_VER}}*
       - numpy >=1.8,{{NPY_VER}}*
       - cython >=0.19*
-      - mkl
+      - mkl # [not win]
     run:
       - python {{PY_VER}}*
       - numpy {{NPY_VER}}*
-      - mkl
+      - mkl # [not win]
       - vs2015_runtime # [win]
 test:
     imports:

--- a/cantera/run_test.py
+++ b/cantera/run_test.py
@@ -1,6 +1,0 @@
-import cantera as ct
-# ar = ct.Element('Ar')
-# print(ar.weight)
-
-gas = ct.Solution('gri30.xml')
-gas()


### PR DESCRIPTION
This PR should collect all the work from #2 and #4 into something that will be easier to maintain longer term. I've done my best to rely on environment variables that are defined by Conda, and rather than installing environments to the global env directory, they are installed into the work directory for better atomization of builds. The version is set in meta.yaml by reading SConstruct now and using a regex to find the version, so that should track with any changes there. I also pinned the versions of conda and conda-build to be installed into the root environment, so hopefully that will be more stable. I would note that those packages tend to be updated pretty often, so we should keep an eye on them, and make sure to keep relatively up-to-date so that we don't have any big surprises in the future.

There is one other thing I'd like to add to this, which is to only upload to Anaconda.org when the build happens from the master branch. Probably the easiest way is just to check the current branch using git commands, but I need to check how Appveyor and Travis do this.

I also don't have admin access to the Appveyor site, so I can't cancel all of these totally unnecessary queued builds.