### PR TITLE
Update conda Numpy versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ install:
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - conda config --set always_yes yes --set changeps1 no
-  - conda install -q anaconda-client conda-build=2.0.12 conda=4.2.13
+  - conda install -q anaconda-client conda-build=2.1.7 conda=4.3.14
   - conda info -a
   - conda list
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,40 +16,40 @@ addons:
 matrix:
   include:
     - os: linux
-      env: BUILD_PYTHON="2.7" BUILD_ARCH="x86"
+      env: BUILD_PYTHON="2.7" BUILD_ARCH="x86" NPY_VER="1.12"
 
     - os: linux
-      env: BUILD_PYTHON="3.4" BUILD_ARCH="x86"
+      env: BUILD_PYTHON="3.4" BUILD_ARCH="x86" NPY_VER="1.11"
 
     - os: linux
-      env: BUILD_PYTHON="3.5" BUILD_ARCH="x86"
+      env: BUILD_PYTHON="3.5" BUILD_ARCH="x86" NPY_VER="1.12"
 
     - os: linux
-      env: BUILD_PYTHON="3.6" BUILD_ARCH="x86"
+      env: BUILD_PYTHON="3.6" BUILD_ARCH="x86" NPY_VER="1.12"
 
     - os: linux
-      env: BUILD_PYTHON="2.7" BUILD_ARCH="x64"
+      env: BUILD_PYTHON="2.7" BUILD_ARCH="x64" NPY_VER="1.12"
 
     - os: linux
-      env: BUILD_PYTHON="3.4" BUILD_ARCH="x64"
+      env: BUILD_PYTHON="3.4" BUILD_ARCH="x64" NPY_VER="1.11"
 
     - os: linux
-      env: BUILD_PYTHON="3.5" BUILD_ARCH="x64"
+      env: BUILD_PYTHON="3.5" BUILD_ARCH="x64" NPY_VER="1.12"
 
     - os: linux
-      env: BUILD_PYTHON="3.6" BUILD_ARCH="x64"
+      env: BUILD_PYTHON="3.6" BUILD_ARCH="x64" NPY_VER="1.12"
 
     - os: osx
-      env: BUILD_PYTHON="2.7" BUILD_ARCH="x64"
+      env: BUILD_PYTHON="2.7" BUILD_ARCH="x64" NPY_VER="1.12"
 
     - os: osx
-      env: BUILD_PYTHON="3.4" BUILD_ARCH="x64"
+      env: BUILD_PYTHON="3.4" BUILD_ARCH="x64" NPY_VER="1.11"
 
     - os: osx
-      env: BUILD_PYTHON="3.5" BUILD_ARCH="x64"
+      env: BUILD_PYTHON="3.5" BUILD_ARCH="x64" NPY_VER="1.12"
 
     - os: osx
-      env: BUILD_PYTHON="3.6" BUILD_ARCH="x64"
+      env: BUILD_PYTHON="3.6" BUILD_ARCH="x64" NPY_VER="1.12"
 
 install:
   - export CONDA_ARCH="${TRAVIS_OS_NAME}_${BUILD_ARCH}"
@@ -69,7 +69,7 @@ install:
   - conda list
 
 script:
-  - conda build cantera --python=${BUILD_PYTHON} --numpy=1.11
+  - conda build cantera --python=${BUILD_PYTHON} --numpy=${NPY_VER}
   - if [ "${TRAVIS_PULL_REQUEST}" == "false" ] && [ "${TRAVIS_BRANCH}" == "master" ]; then
       anaconda -t $ANACONDA_TOKEN upload --force -l dev $HOME/miniconda/conda-bld/*/cantera*.tar.bz2;
     else

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,6 @@ matrix:
       env: BUILD_PYTHON="2.7" BUILD_ARCH="x86" NPY_VER="1.12"
 
     - os: linux
-      env: BUILD_PYTHON="3.4" BUILD_ARCH="x86" NPY_VER="1.11"
-
-    - os: linux
       env: BUILD_PYTHON="3.5" BUILD_ARCH="x86" NPY_VER="1.12"
 
     - os: linux
@@ -31,9 +28,6 @@ matrix:
       env: BUILD_PYTHON="2.7" BUILD_ARCH="x64" NPY_VER="1.12"
 
     - os: linux
-      env: BUILD_PYTHON="3.4" BUILD_ARCH="x64" NPY_VER="1.11"
-
-    - os: linux
       env: BUILD_PYTHON="3.5" BUILD_ARCH="x64" NPY_VER="1.12"
 
     - os: linux
@@ -41,9 +35,6 @@ matrix:
 
     - os: osx
       env: BUILD_PYTHON="2.7" BUILD_ARCH="x64" NPY_VER="1.12"
-
-    - os: osx
-      env: BUILD_PYTHON="3.4" BUILD_ARCH="x64" NPY_VER="1.11"
 
     - os: osx
       env: BUILD_PYTHON="3.5" BUILD_ARCH="x64" NPY_VER="1.12"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,11 +10,6 @@ environment:
       NPY_VER: "1.12"
 
     - PYTHON_LOC: "C:\\Miniconda"
-      PYTHON_VERSION: "3.4"
-      BUILD_ARCH: "32"
-      NPY_VER: "1.11"
-
-    - PYTHON_LOC: "C:\\Miniconda"
       PYTHON_VERSION: "3.5"
       BUILD_ARCH: "32"
       NPY_VER: "1.12"
@@ -28,11 +23,6 @@ environment:
       PYTHON_VERSION: "2.7"
       BUILD_ARCH: "64"
       NPY_VER: "1.12"
-
-    - PYTHON_LOC: "C:\\Miniconda-x64"
-      PYTHON_VERSION: "3.4"
-      BUILD_ARCH: "64"
-      NPY_VER: "1.11"
 
     - PYTHON_LOC: "C:\\Miniconda-x64"
       PYTHON_VERSION: "3.5"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,34 +7,42 @@ environment:
     - PYTHON_LOC: "C:\\Miniconda"
       PYTHON_VERSION: "2.7"
       BUILD_ARCH: "32"
+      NPY_VER: "1.12"
 
     - PYTHON_LOC: "C:\\Miniconda"
       PYTHON_VERSION: "3.4"
       BUILD_ARCH: "32"
+      NPY_VER: "1.11"
 
     - PYTHON_LOC: "C:\\Miniconda"
       PYTHON_VERSION: "3.5"
       BUILD_ARCH: "32"
+      NPY_VER: "1.12"
 
     - PYTHON_LOC: "C:\\Miniconda"
       PYTHON_VERSION: "3.6"
       BUILD_ARCH: "32"
+      NPY_VER: "1.12"
 
     - PYTHON_LOC: "C:\\Miniconda-x64"
       PYTHON_VERSION: "2.7"
       BUILD_ARCH: "64"
+      NPY_VER: "1.12"
 
     - PYTHON_LOC: "C:\\Miniconda-x64"
       PYTHON_VERSION: "3.4"
       BUILD_ARCH: "64"
+      NPY_VER: "1.11"
 
     - PYTHON_LOC: "C:\\Miniconda-x64"
       PYTHON_VERSION: "3.5"
       BUILD_ARCH: "64"
+      NPY_VER: "1.12"
 
     - PYTHON_LOC: "C:\\Miniconda-x64"
       PYTHON_VERSION: "3.6"
       BUILD_ARCH: "64"
+      NPY_VER: "1.12"
 
 install:
   - cmd: set PATH=%PYTHON_LOC%;%PYTHON_LOC%\Scripts;%PATH%
@@ -46,7 +54,7 @@ install:
 
 build_script:
   - cmd: set PATH=%PYTHON_LOC%;%PYTHON_LOC%\Scripts;%PATH%
-  - cmd: conda build cantera --python=%PYTHON_VERSION% --numpy=1.11
+  - cmd: conda build cantera --python=%PYTHON_VERSION% --numpy=%NPY_VER%
 
 deploy_script:
   - cmd: set PATH=%PYTHON_LOC%;%PYTHON_LOC%\Scripts;%PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,7 +38,7 @@ environment:
 
 install:
   - cmd: set PATH=%PYTHON_LOC%;%PYTHON_LOC%\Scripts;%PATH%
-  - cmd: conda install -yq anaconda-client conda=4.2.13 conda-build=2.0.12
+  - cmd: conda install -yq anaconda-client conda=4.3.14 conda-build=2.1.7
   - cmd: conda info -a
   - cmd: conda list
   - ps: Write-Host $env:APPVEYOR_REPO_BRANCH

--- a/cantera/build.sh
+++ b/cantera/build.sh
@@ -24,14 +24,17 @@ scons clean
 echo "matlab_toolbox='n'" >> cantera.conf
 echo "f90_interface='n'" >> cantera.conf
 echo "system_sundials='n'" >> cantera.conf
-echo "blas_lapack_libs = 'mkl_rt,dl'" >> cantera.conf
 echo "debug='n'" >> cantera.conf
-echo "blas_lapack_dir = '$PREFIX/lib'" >> cantera.conf
 echo "boost_inc_dir = '$PREFIX/../cantera-builder/include'" >> cantera.conf
 
 if [[ "$CONDA_ARCH" == "linux_x86" ]]; then
   echo "cc_flags='-m32'" >> cantera.conf
   echo "no_debug_linker_flags='-m32'" >> cantera.conf
+fi
+
+if [[ "$CONDA_ARCH" != "osx_x64" ]]; then
+    echo "blas_lapack_libs = 'mkl_rt,dl'" >> cantera.conf
+    echo "blas_lapack_dir = '$PREFIX/lib'" >> cantera.conf
 fi
 
 set -x

--- a/cantera/meta.yaml
+++ b/cantera/meta.yaml
@@ -7,7 +7,7 @@ source:
     git_url: https://github.com/Cantera/cantera.git
     git_tag: master
 build:
-    number: 2
+    number: 0
     string: np{{CONDA_NPY}}py{{CONDA_PY}}_{{PKG_BUILDNUM}}_g{{GIT_FULL_HASH[:7]}}
     script_env:
       - CONDA_ARCH

--- a/cantera/meta.yaml
+++ b/cantera/meta.yaml
@@ -19,11 +19,11 @@ requirements:
     build:
       - python >=2.7,<3|>=3.3,{{PY_VER}}*
       - numpy >=1.8,{{NPY_VER}}*
-      - mkl # [not win]
+      - mkl # [linux]
     run:
       - python {{PY_VER}}*
       - numpy {{NPY_VER}}*
-      - mkl # [not win]
+      - mkl # [linux]
       - vs2015_runtime # [win]
 test:
     imports:


### PR DESCRIPTION
This branch

* updates versions of conda and conda-build
* updates numpy to 1.12
* removes Python 3.4 from the build matrix, because numpy 1.12 isn't available for Python 3.4 from Continuum
* switches to the Accelerate framework on OS X instead of MKL because MKL version 2017.01.0 causes a test failure regarding ignition delay sensitivity

The latest Appveyor build failed because I canceled it, but previous builds passed before I force-pushed, so I think it will work fine.