### PR TITLE
Add instructions for local conda-build on Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*~
+*#
+channeldata.json
+index.html

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
-This repository hosts the recipe to build the Python interface for Cantera into a conda package. The package is built on GitHub Actions and uploaded to Anaconda.org automatically.
+This repository hosts the recipe to build the Python interface for Cantera into a `conda` package. The package is built on GitHub Actions and uploaded to the `cantera` channel on [anaconda.org](https://anaconda.org/search?q=cantera) automatically.
+
+**Important:** the `conda-forge` recipe is maintained in a separate repository ([conda-forge/cantera-feedstock](https://github.com/conda-forge/cantera-feedstock)).
 
 ![CI](https://github.com/Cantera/conda-recipes/workflows/CI/badge.svg)


### PR DESCRIPTION
- Update `README.md`
- Add `.gitignore`
- ~Add instructions for running `conda-build` locally on Linux.~ ... *Edit: decided to move instructions to a [gist](https://gist.github.com/ischoegl/b7c935bb3c94403f3f4d4e5db67ac116)*