### PR TITLE
Fix windows and cantera-matlab builds

### DIFF
--- a/cantera-matlab/bld.bat
+++ b/cantera-matlab/bld.bat
@@ -30,10 +30,10 @@ IF ERRORLEVEL 1 EXIT 1
 :: prevent this package from clobbering any existing
 :: libcantera or Cantera Python interface files, possibly except the
 :: data files and the license file.
-ROBOCOPY "%STAGE_DIR%\%PREFIX_DIR%\samples\matlab" "%LIBRARY_PREFIX%\cantera\samples\matlab" /S /E
-ROBOCOPY "%STAGE_DIR%\%PREFIX_DIR%\matlab" "%LIBRARY_LIB%\cantera\matlab" /S /E
-ROBOCOPY "%STAGE_DIR%\%PREFIX_DIR%\data" "%LIBRARY_PREFIX%\cantera\data" /S /E
-ROBOCOPY "%STAGE_DIR%\%PREFIX_DIR%\doc" "%LIBRARY_PREFIX%\cantera\doc" /S /E
+ROBOCOPY "%STAGE_DIR%\%PREFIX_DIR%\share\cantera\samples\matlab" "%PREFIX%\share\cantera\samples\matlab" /S /E
+ROBOCOPY "%STAGE_DIR%\%PREFIX_DIR%\share\cantera\matlab" "%PREFIX%\share\cantera\matlab" /S /E
+ROBOCOPY "%STAGE_DIR%\%PREFIX_DIR%\share\cantera\data" "%PREFIX%\share\cantera\data" /S /E
+ROBOCOPY "%STAGE_DIR%\%PREFIX_DIR%\share\cantera\doc" "%PREFIX%\share\cantera\doc" /S /E
 
 echo ****************************
 echo MATLAB BUILD COMPLETED SUCCESSFULLY

--- a/cantera-matlab/build.sh
+++ b/cantera-matlab/build.sh
@@ -47,7 +47,7 @@ cp -R "${STAGE_DIR}/${PREFIX_DIR}/${CT_DATA_DIR}/" "${PREFIX}/${CT_DATA_DIR}"
 CT_DOC_DIR="share/cantera/doc"
 mkdir -p "${PREFIX}/${CT_DOC_DIR}"
 cp -R "${STAGE_DIR}/${PREFIX_DIR}/${CT_DOC_DIR}/" "${PREFIX}/${CT_DOC_DIR}"
-CT_LIB_DIR="lib/cantera/matlab"
+CT_LIB_DIR="share/cantera/matlab"
 mkdir -p "${PREFIX}/${CT_LIB_DIR}"
 cp -R "${STAGE_DIR}/${PREFIX_DIR}/${CT_LIB_DIR}/" "${PREFIX}/${CT_LIB_DIR}"
 

--- a/cantera-matlab/post-link.bat
+++ b/cantera-matlab/post-link.bat
@@ -15,5 +15,5 @@ IF EXIST "%MATLAB_STARTUP%.cantera.bak" FINDSTR /V "%% added by Cantera Conda In
 
 REM Add Cantera lines to the startup.m script
 ECHO. >> "%MATLAB_STARTUP%"
-ECHO setenv('CANTERA_DATA', '%PREFIX%\Library\cantera\data') %% added by Cantera Conda Installer for %CONDA_ENV% environment>> "%MATLAB_STARTUP%"
-ECHO addpath(genpath('%PREFIX%\Library\lib\cantera\matlab')) %% added by Cantera Conda Installer for %CONDA_ENV% environment>> "%MATLAB_STARTUP%"
+ECHO setenv('CANTERA_DATA', '%PREFIX%\share\cantera\data') %% added by Cantera Conda Installer for %CONDA_ENV% environment>> "%MATLAB_STARTUP%"
+ECHO addpath(genpath('%PREFIX%\share\cantera\matlab')) %% added by Cantera Conda Installer for %CONDA_ENV% environment>> "%MATLAB_STARTUP%"

--- a/cantera-matlab/post-link.sh
+++ b/cantera-matlab/post-link.sh
@@ -13,5 +13,5 @@ if [ -f "${MATLAB_STARTUP}" ]; then
 fi
 
 echo "
-addpath(genpath('${PREFIX}/lib/cantera/matlab')) % added by Cantera ${PKG_VERSION} Conda installer for ${CONDA_ENV} environment
+addpath(genpath('${PREFIX}/share/cantera/matlab')) % added by Cantera ${PKG_VERSION} Conda installer for ${CONDA_ENV} environment
 setenv('CANTERA_DATA', '${PREFIX}/share/cantera/data') % added by Cantera ${PKG_VERSION} Conda installer for ${CONDA_ENV} environment" >> ${MATLAB_STARTUP}

--- a/cantera/bld.bat
+++ b/cantera/bld.bat
@@ -12,7 +12,7 @@ SET /A CPU_USE=%CPU_COUNT% / 2
 IF %CPU_USE% EQU 0 SET CPU_USE=1
 
 SET "ESC_PREFIX=%PREFIX:\=/%"
-ECHO prefix="%ESC_PREFIX%/Library" >> cantera.conf
+ECHO prefix="%ESC_PREFIX%" >> cantera.conf
 ECHO boost_inc_dir="%ESC_PREFIX%/Library/include" >> cantera.conf
 
 CALL scons build -j%CPU_USE%

--- a/cantera/build_lib.bat
+++ b/cantera/build_lib.bat
@@ -3,8 +3,14 @@ echo "****************************"
 echo "DELETING files from devel except shared libraries and data"
 echo "****************************"
 
-rd /s /q %PREFIX%\Library\share\cantera\doc
-rd /s /q %PREFIX%\Library\share\cantera\samples
-rd /s /q %PREFIX%\Library\share\man
-rd /s /q %PREFIX%\Library\share
+rd /s /q %PREFIX%\share\cantera\doc
+rd /s /q %PREFIX%\share\cantera\samples
+rd /s /q %PREFIX%\share\man
 rd /s /q %PREFIX%\Library\include\cantera
+rd /s /q %PREFIX%\Scripts
+del /f %PREFIX%\Library\lib\cantera.lib
+del /f %PREFIX%\Library\lib\cantera_shared.lib
+
+echo "****************************"
+echo "DELETING files COMPLETED"
+echo "****************************"

--- a/cantera/build_lib.sh
+++ b/cantera/build_lib.sh
@@ -8,7 +8,7 @@ rm -rf $PREFIX/share/cantera/samples
 rm -rf $PREFIX/share/man
 rm -rf $PREFIX/include/cantera
 rm -rf $PREFIX/bin
-rm -rf $PREFIX/lib/pkg-config
+rm -rf $PREFIX/lib/pkgconfig
 rm -rf $PREFIX/lib/libcantera.a
 
 if [[ "$target_platform" == osx-* ]]; then

--- a/cantera/build_py.bat
+++ b/cantera/build_py.bat
@@ -2,20 +2,23 @@ echo ****************************
 echo PYTHON %PYTHON% BUILD STARTED
 echo ****************************
 
-COPY cantera.conf cantera.conf.bak
-DEL /F cantera.conf
-FINDSTR /V "python_package" cantera.conf.bak > cantera.conf
-DEL /F cantera.conf.bak
+:: Remove old Python build files, if they are present
+IF EXIST "build/python" RD /S /Q "build/python"
+IF EXIST "build/temp-py" RD /S /Q "build/temp-py"
+IF EXIST "%PREFIX%/bin/ck2yaml" DEL /F "%PREFIX%/bin/ck2yaml"
+IF EXIST "%PREFIX%/bin/cti2yaml" DEL /F "%PREFIX%/bin/cti2yaml"
+IF EXIST "%PREFIX%/bin/ctml2yaml" DEL /F "%PREFIX%/bin/ctml2yaml"
+IF EXIST "%PREFIX%/bin/yaml2ck" DEL /F "%PREFIX%/bin/yaml2ck"
 
-ECHO python_package='full' >> cantera.conf
 SET "ESC_PYTHON=%PYTHON:\=/%"
 ECHO python_cmd="%ESC_PYTHON%" >> cantera.conf
-CALL scons build
+
+CALL scons build python_package=y
+IF ERRORLEVEL 1 EXIT 1
+
+"%PYTHON%" -m pip install --no-deps --no-index --find-links=build\python\dist\ cantera
 IF ERRORLEVEL 1 EXIT 1
 
 echo ****************************
 echo PYTHON %PYTHON% BUILD COMPLETED SUCCESSFULLY
 echo ****************************
-
-"%PYTHON%" -m pip install --no-deps --no-index --find-links=build\python\dist\ cantera
-IF ERRORLEVEL 1 EXIT 1

--- a/cantera/build_py.bat
+++ b/cantera/build_py.bat
@@ -19,6 +19,8 @@ IF ERRORLEVEL 1 EXIT 1
 "%PYTHON%" -m pip install --no-deps --no-index --find-links=build\python\dist\ cantera
 IF ERRORLEVEL 1 EXIT 1
 
+ROBOCOPY "%SRC_DIR%\samples\python" "%PREFIX%\share\cantera\samples\python" /S /E
+
 echo ****************************
 echo PYTHON %PYTHON% BUILD COMPLETED SUCCESSFULLY
 echo ****************************

--- a/cantera/build_py.sh
+++ b/cantera/build_py.sh
@@ -16,6 +16,8 @@ ${BUILD_PREFIX}/bin/python `which scons` build python_package='y' python_cmd="${
 
 $PYTHON -m pip install --no-deps --no-index --find-links=build/python/dist cantera
 
+cp -r $SRC_DIR/samples/python $PREFIX/share/cantera/samples/python
+
 if [[ "$target_platform" == osx-* ]]; then
    VERSION=$(echo $PKG_VERSION | cut -da -f1 | cut -db -f1 | cut -dr -f1)
    file_to_fix=$(find $SP_DIR -name "_cantera*.so" | head -n 1)


### PR DESCRIPTION
While #33 fixes `conda` packages on macOS and linux, the windows build still fails for `cantera`, while all builds fail for `cantera-matlab`.

Fixes #20

Some paths require updates based on the SCons option `layout=conda` going back to Cantera/cantera#1191, which is not completely consistent with choices in `conda-recipes`. 

Among others, the MATLAB toolbox is installed in `share/cantera/lib` (all platforms), which is different from `lib/cantera/matlab` (macOS/Linux) and `Library\lib\cantera\matlab` (win). I am suggesting to keep `conda-recipes` consistent with `layout=conda` (as matlab is not a Unix-style library). As paths are automatically set with `startup.m`, this change is likely inconsequential for end users.

Fwiw, the current `layout=conda` configuration looks as follows on Windows:
```
*************** Cantera 3.0.0a2 has been successfully installed ****************

File locations:

  library files               C:\Users\ischo\miniconda3\envs\cantera-dev\Library\lib
  C++ headers                 C:\Users\ischo\miniconda3\envs\cantera-dev\Library\include
  samples                     C:/Users/ischo/miniconda3/envs/cantera-dev\share\cantera\samples
  data files                  C:/Users/ischo/miniconda3/envs/cantera-dev\share\cantera\data
  input file converters       C:\Users\ischo\miniconda3\envs\cantera-dev\Scripts
  Python package              C:\Users\ischo\miniconda3\envs\cantera-dev\Lib\site-packages
  Python examples             C:/Users/ischo/miniconda3/envs/cantera-dev\share\cantera\samples\python
  Matlab toolbox              C:/Users/ischo/miniconda3/envs/cantera-dev\share\cantera\matlab\toolbox
  Matlab samples              C:/Users/ischo/miniconda3/envs/cantera-dev\share\cantera\samples\matlab

An m-file to set the correct matlab path for Cantera is at:

  C:/Users/ischo/miniconda3/envs/cantera-dev\share\cantera\matlab\toolbox\ctpath.m


********************************************************************************
```