### PR TITLE
Update libcantera-devel

### DIFF
--- a/.ci_support/cantera_base.conf
+++ b/.ci_support/cantera_base.conf
@@ -1,5 +1,5 @@
 use_pch = False
-f90_interface = 'n'
+f90_interface = 'default'
 system_sundials = 'n'
 debug = 'n'
 python_package = 'none'

--- a/.ci_support/cantera_base.conf
+++ b/.ci_support/cantera_base.conf
@@ -5,3 +5,4 @@ debug = 'n'
 python_package = 'none'
 googletest = 'none'
 layout = 'conda'
+package_build = True

--- a/cantera-matlab/build.sh
+++ b/cantera-matlab/build.sh
@@ -38,18 +38,13 @@ ${BUILD_PREFIX}/bin/python ${BUILD_PREFIX}/bin/scons install
 # prevent this package from clobbering any existing
 # libcantera or Cantera Python interface files, except the
 # data files and the license file.
-CT_SAMPLES_DIR="share/cantera/samples/matlab"
+CT_SAMPLES_DIR="share/cantera/samples"
 mkdir -p "${PREFIX}/${CT_SAMPLES_DIR}"
-cp -R "${STAGE_DIR}/${PREFIX_DIR}/${CT_SAMPLES_DIR}/" "${PREFIX}/${CT_SAMPLES_DIR}"
-CT_DATA_DIR="share/cantera/data"
-mkdir -p "${PREFIX}/${CT_DATA_DIR}"
-cp -R "${STAGE_DIR}/${PREFIX_DIR}/${CT_DATA_DIR}/" "${PREFIX}/${CT_DATA_DIR}"
-CT_DOC_DIR="share/cantera/doc"
-mkdir -p "${PREFIX}/${CT_DOC_DIR}"
-cp -R "${STAGE_DIR}/${PREFIX_DIR}/${CT_DOC_DIR}/" "${PREFIX}/${CT_DOC_DIR}"
-CT_LIB_DIR="share/cantera/matlab"
-mkdir -p "${PREFIX}/${CT_LIB_DIR}"
-cp -R "${STAGE_DIR}/${PREFIX_DIR}/${CT_LIB_DIR}/" "${PREFIX}/${CT_LIB_DIR}"
+cp -R "${STAGE_DIR}/${PREFIX_DIR}/${CT_SAMPLES_DIR}/matlab" "${PREFIX}/${CT_SAMPLES_DIR}/"
+CT_SHARED_DIR="share/cantera"
+cp -R "${STAGE_DIR}/${PREFIX_DIR}/${CT_SHARED_DIR}/data" "${PREFIX}/${CT_SHARED_DIR}/"
+cp -R "${STAGE_DIR}/${PREFIX_DIR}/${CT_SHARED_DIR}/doc" "${PREFIX}/${CT_SHARED_DIR}/"
+cp -R "${STAGE_DIR}/${PREFIX_DIR}/${CT_SHARED_DIR}/matlab" "${PREFIX}/${CT_SHARED_DIR}/"
 
 set +xe
 

--- a/cantera/build_devel.bat
+++ b/cantera/build_devel.bat
@@ -4,6 +4,11 @@ ECHO ************************
 
 CALL scons install
 
+RD /S /Q "%PREFIX%/share/cantera/samples"
+ROBOCOPY "%SRC_DIR%/samples/cxx" "%PREFIX%/share/cantera/samples/cxx" /S /E
+DEL /F "%PREFIX%/share/cantera/samples/cxx/SCons*"
+DEL /F "%PREFIX%/share/cantera/samples/cxx/*Make*"
+
 ECHO ************************
 ECHO DEVEL BUILD COMPLETED SUCCESSFULLY
 ECHO ************************

--- a/cantera/build_devel.bat
+++ b/cantera/build_devel.bat
@@ -4,11 +4,6 @@ ECHO ************************
 
 CALL scons install
 
-RD /S /Q "%PREFIX%/share/cantera/samples"
-ROBOCOPY "%SRC_DIR%/samples/cxx" "%PREFIX%/share/cantera/samples/cxx" /S /E
-DEL /F "%PREFIX%/share/cantera/samples/cxx/SCons*"
-DEL /F "%PREFIX%/share/cantera/samples/cxx/*Make*"
-
 ECHO ************************
 ECHO DEVEL BUILD COMPLETED SUCCESSFULLY
 ECHO ************************

--- a/cantera/build_devel.sh
+++ b/cantera/build_devel.sh
@@ -7,11 +7,6 @@ set -e
 ${BUILD_PREFIX}/bin/python `which scons` install
 set +e
 
-rm -r $PREFIX/share/cantera/samples
-cp -r $SRC_DIR/samples/cxx $PREFIX/share/cantera/samples/cxx
-rm $PREFIX/share/cantera/samples/cxx/SCons*
-rm $PREFIX/share/cantera/samples/cxx/*Make*
-
 echo "*****************************"
 echo "DEVEL LIBRARY BUILD COMPLETED"
 echo "*****************************"

--- a/cantera/build_devel.sh
+++ b/cantera/build_devel.sh
@@ -7,6 +7,11 @@ set -e
 ${BUILD_PREFIX}/bin/python `which scons` install
 set +e
 
+rm -r $PREFIX/share/cantera/samples
+cp -r $SRC_DIR/samples/cxx $PREFIX/share/cantera/samples/cxx
+rm $PREFIX/share/cantera/samples/cxx/SCons*
+rm $PREFIX/share/cantera/samples/cxx/*Make*
+
 echo "*****************************"
 echo "DEVEL LIBRARY BUILD COMPLETED"
 echo "*****************************"

--- a/cantera/build_devel.sh
+++ b/cantera/build_devel.sh
@@ -7,6 +7,8 @@ set -e
 ${BUILD_PREFIX}/bin/python `which scons` install
 set +e
 
+rm -rf $PREFIX/share/man
+
 echo "*****************************"
 echo "DEVEL LIBRARY BUILD COMPLETED"
 echo "*****************************"

--- a/cantera/build_lib.bat
+++ b/cantera/build_lib.bat
@@ -5,7 +5,6 @@ echo "****************************"
 
 rd /s /q %PREFIX%\share\cantera\doc
 rd /s /q %PREFIX%\share\cantera\samples
-rd /s /q %PREFIX%\share\man
 rd /s /q %PREFIX%\Library\include\cantera
 rd /s /q %PREFIX%\Scripts
 del /f %PREFIX%\Library\lib\cantera.lib

--- a/cantera/build_lib.sh
+++ b/cantera/build_lib.sh
@@ -5,7 +5,6 @@ echo "****************************"
 
 rm -rf $PREFIX/share/cantera/doc
 rm -rf $PREFIX/share/cantera/samples
-rm -rf $PREFIX/share/man
 rm -rf $PREFIX/include/cantera
 rm -rf $PREFIX/bin
 rm -rf $PREFIX/lib/pkgconfig

--- a/cantera/build_py.sh
+++ b/cantera/build_py.sh
@@ -18,6 +18,8 @@ $PYTHON -m pip install --no-deps --no-index --find-links=build/python/dist cante
 
 mkdir -p $PREFIX/share/cantera/samples
 cp -r $SRC_DIR/samples/python $PREFIX/share/cantera/samples/
+mkdir -p $PREFIX/share/man
+cp -r $SRC_DIR/platform/posix/man/* $PREFIX/share/man/man1/
 
 if [[ "$target_platform" == osx-* ]]; then
    VERSION=$(echo $PKG_VERSION | cut -da -f1 | cut -db -f1 | cut -dr -f1)

--- a/cantera/build_py.sh
+++ b/cantera/build_py.sh
@@ -16,7 +16,8 @@ ${BUILD_PREFIX}/bin/python `which scons` build python_package='y' python_cmd="${
 
 $PYTHON -m pip install --no-deps --no-index --find-links=build/python/dist cantera
 
-cp -r $SRC_DIR/samples/python $PREFIX/share/cantera/samples/python
+mkdir -p $PREFIX/share/cantera/samples
+cp -r $SRC_DIR/samples/python $PREFIX/share/cantera/samples/
 
 if [[ "$target_platform" == osx-* ]]; then
    VERSION=$(echo $PKG_VERSION | cut -da -f1 | cut -db -f1 | cut -dr -f1)

--- a/cantera/meta.yaml
+++ b/cantera/meta.yaml
@@ -32,6 +32,7 @@ outputs:
       ignore_run_exports_from:
         # only the header part of these libraries are used
         - libboost
+        - {{ compiler('fortran') }}  # [not win]
       run_exports:
         - libcantera
     requirements:
@@ -59,6 +60,8 @@ outputs:
       build:
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
+        # At the moment, the toolchain does not provide Fortran for Windows
+        - {{ compiler('fortran') }}  # [not win]
         - scons >=4.1
       host:
         - libboost

--- a/cantera/meta.yaml
+++ b/cantera/meta.yaml
@@ -129,6 +129,10 @@ outputs:
         - ck2yaml --help
         - ctml2yaml --help
         - yaml2ck --help
+        - man ck2yaml  # [not win]
+        - man cti2yaml  # [not win]
+        - man ctml2yaml  # [not win]
+        - man yaml2ck  # [not win]
 
 about:
   home: https://cantera.org

--- a/cantera/meta.yaml
+++ b/cantera/meta.yaml
@@ -55,10 +55,6 @@ outputs:
     script: build_devel.sh  # [not win]
     script: build_devel.bat  # [win]
 
-    build:
-      ignore_run_exports_from:
-        # only the header part of these libraries are used
-        - libboost
     requirements:
       build:
         - {{ compiler('c') }}
@@ -71,6 +67,7 @@ outputs:
         - pywin32  # [win]
         - libcantera {{ version }}
       run:
+        - libboost
         - {{ pin_subpackage('libcantera', exact=True) }}
 
   - name: cantera


### PR DESCRIPTION
This PR includes some minor updates:

- Include Fortran modules in `libcantera-devel`
- ~Create "clean" sample folders for `cxx` and `f90`~
- Install `man` pages in `cantera`
- Ensure that `libboost` is a dependency for `libcantera-devel`
- Fix extra level in `matlab` folder structure
- Add SCons option `package_build = True`

Closes #37.